### PR TITLE
AiiDA pseudo is needed to the examples with quantum espresso,

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ requires-python = '>=3.8'
 
 dependencies = [
     'aiida-core>=2.1.0<3',
-    'aiida-pseudo>=0.8.0,<2',
     'oteapi-core>=0.4.1,<0.4.4',
     'oteapi-dlite>=0.1.4,<0.1.5',
     'DLite-Python>=0.3.20,<0.4.1',


### PR DESCRIPTION
As far as I see AiiDA pseudo is not needed for running ExecFlow itself.
AiiDA pseudo should therefore not be a core-requirement.

Also note that AiiDA-pseudo has a very strict requirement for pint which will easily be problematic for other dependencies, so best to not have aiida-pseudo as a requirement if it is not needed. 