### PR TITLE
Run ExecFlow in JupyterLab (with AiiDA)

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,9 +31,11 @@ jobs:
       # Ignore some safety warnings:
       # - 63227: paramiko. Subdependency of aiida-core.
       # - 59901: aio-pika. Subdependency of aiida-core.
+      # - 65193: paramiko. Subdependency of aiida-core.
       safety_options: |
         --ignore=63227
         --ignore=59901
+        --ignore=65193
 
       # Build package
       run_build_package: true

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -164,3 +164,18 @@ jobs:
       with:
         files: coverage.xml
         flags: windows-extra_libs
+
+  build-docker:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Test building Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
   # To get an overview of them all as well as the ones used here, please see
   # https://github.com/pre-commit/pre-commit-hooks#hooks-available
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
     - id: end-of-file-fixer
       exclude: ^.*\.(drawio|svg)$
@@ -30,7 +30,7 @@ repos:
   # Black is a code style and formatter
   # It works on files in-place
   - repo: https://github.com/ambv/black
-    rev: 24.2.0
+    rev: 24.4.2
     hooks:
     - id: black
 
@@ -38,7 +38,7 @@ repos:
   # More information can be found in its documentation:
   # https://bandit.readthedocs.io/en/latest/
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.7
+    rev: 1.7.8
     hooks:
     - id: bandit
       args: ["-r"]
@@ -50,7 +50,7 @@ repos:
   # The project's documentation can be found at:
   # https://mypy.readthedocs.io/en/stable/index.html
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.10.0
     hooks:
     - id: mypy
       exclude: ^tests/.*$
@@ -58,33 +58,3 @@ repos:
         - "types-PyYAML"
         - "pydantic>=2"
         - "types-requests"
-
-  # - repo: local
-  #   hooks:
-  #   # pylint is a Python linter
-  #   # It is run through the local environment to ensure external packages can be
-  #   # imported without issue.
-  #   # For more information about pylint see its documentation at:
-  #   # https://pylint.pycqa.org/en/latest/
-  #   - id: pylint
-  #     name: pylint
-  #     entry: pylint
-  #     args:
-  #     # - "--rcfile=pyproject.toml"
-  #     - "--extension-pkg-whitelist='pydantic'"
-  #     language: python
-  #     types: [python]
-  #     require_serial: true
-  #     files: ^.*$
-  #     exclude: ^tests/.*$
-  #   - id: pylint-tests
-  #     name: pylint - tests
-  #     entry: pylint
-  #     args:
-  #     # - "--rcfile=pyproject.toml"
-  #     - "--extension-pkg-whitelist='pydantic'"
-  #     - "--disable=import-outside-toplevel,redefined-outer-name"
-  #     language: python
-  #     types: [python]
-  #     require_serial: true
-  #     files: ^tests/.*$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM aiidalab/base-with-services:latest
+
+USER ${NB_USER}
+WORKDIR "/home/${NB_USER}"
+
+RUN python3 -m venv ${HOME}/openmodel \
+    && source ${HOME}/openmodel/bin/activate \
+    && pip install --upgrade pip setuptools wheel \
+    && pip install ipykernel git+https://github.com/H2020-OpenModel/ExecFlow.git@cwa/fix-26-support-aiida-v24 \
+    && python -m ipykernel install --user --name=openmodel --display-name="Open Model ExecFlow"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ WORKDIR "/home/${NB_USER}"
 RUN python3 -m venv ${HOME}/openmodel
 RUN source ${HOME}/openmodel/bin/activate
 RUN pip install --upgrade pip setuptools wheel
-RUN pip install ipykernel git+https://github.com/H2020-OpenModel/ExecFlow.git@cwa/fix-26-support-aiida-v24
+RUN pip install ipykernel git+https://github.com/H2020-OpenModel/ExecFlow.git
 RUN python -m ipykernel install --user --name=openmodel --display-name="OpenModel ExecFlow"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM aiidalab/base-with-services:latest
 USER ${NB_USER}
 WORKDIR "/home/${NB_USER}"
 
-RUN python3 -m venv ${HOME}/openmodel \
-    && source ${HOME}/openmodel/bin/activate \
-    && pip install --upgrade pip setuptools wheel \
-    && pip install ipykernel git+https://github.com/H2020-OpenModel/ExecFlow.git@cwa/fix-26-support-aiida-v24 \
-    && python -m ipykernel install --user --name=openmodel --display-name="OpenModel ExecFlow"
+RUN python3 -m venv ${HOME}/openmodel
+RUN source ${HOME}/openmodel/bin/activate
+RUN pip install --upgrade pip setuptools wheel
+RUN pip install ipykernel git+https://github.com/H2020-OpenModel/ExecFlow.git@cwa/fix-26-support-aiida-v24
+RUN python -m ipykernel install --user --name=openmodel --display-name="OpenModel ExecFlow"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN python3 -m venv ${HOME}/openmodel \
     && source ${HOME}/openmodel/bin/activate \
     && pip install --upgrade pip setuptools wheel \
     && pip install ipykernel git+https://github.com/H2020-OpenModel/ExecFlow.git@cwa/fix-26-support-aiida-v24 \
-    && python -m ipykernel install --user --name=openmodel --display-name="Open Model ExecFlow"
+    && python -m ipykernel install --user --name=openmodel --display-name="OpenModel ExecFlow"

--- a/README.md
+++ b/README.md
@@ -156,6 +156,28 @@ repository and use `pip`:
 pip install -e .
 ```
 
+## Run in JupyterLab
+
+The root [Dockerfile](./Dockerfile) contains the necessary setup to run ExecFlow in a JupyterLab environment.
+To run the JupyterLab environment, execute the following command:
+
+```bash
+# Build the Docker image
+docker build -t omilab .
+
+# Run the Docker container
+docker run -it -p 8888:8888 omilab
+```
+
+This will start a JupyterLab server in the container.
+The URL to access the server will be printed in the terminal (use the link with the 127.0.0.1 host).
+
+For the JupyterLab environment, you should first open a terminal (found under the "Other" section) and write `verdi status` to check the AiiDA installation.
+Then you can start working in a notebook to use ExecFlow by starting the "OpenModel ExecFlow" Python kernel (see the box in the top-most section).
+
+> **Note** If any issues should arise with regards to AiiDA, such as the AiiDA installation not checking out, please refer to the [AiiDA documentation](https://aiida.readthedocs.io/projects/aiida-core/en/stable/) or contact the AiiDA team.
+> Furthermore, if other issues should arise, please open an issue in this repository.
+
 ## Acknowledgements
 
 The `DeclarativeChain` was developed and design with help and input of Simon Adorf (@csadorf).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # ExecFlow
+
 This repo holds all the parts that relate to ExecFlow.
 
-# Declarative Chain
+## Declarative Chain
+
 This is a self assembling workchain that utilizes json or yaml files to specify both the steps in the workchain as well as the data to be used with it.
 
-## Syntax
+### Syntax
+
 The overall structure of the input files are as follows:
+
 ```yaml
 ---
 steps:
@@ -13,10 +17,13 @@ steps:
   inputs:
     <dict with inputs for the calcjob>
 ```
+
 The array of steps will be ran sequentially inside the workchain. The structure above is the most basic form of a workflow file.
 
-### Data Referencing
+#### Data Referencing
+
 To keep the files clean and readable, it is possible to first specify some data and then reference it in the `steps` part of the workflow file. For example:
+
 ```yaml
 ---
 data:
@@ -31,24 +38,31 @@ steps:
         "$ref": "#/data/kpoints"
     <other inputs>
 ```
+
 will paste the definition of `kpoints` in the `data` section into the input where it's referenced. This uses [jsonref](https://pypi.org/project/jsonref/), see its documentation for more possibilities. It is for example also possible to reference data from an external json/yaml file.
 
-### Jinja templates
+#### Jinja templates
+
 Often, we want to use the workchain context `self.ctx` to store and retrieve intermediate results throughout the workchain's execution. To facilitate this we can use [jinja](https://jinja.palletsprojects.com/en/3.1.x/) templates such as:
 `"{{ ctx.scf_dir }}"` to resolve certain values into the yaml script. The use of will become clear later.
 
-### Setup
+#### Setup
+
 The top level `setup` statement allows for specifying some templates that will be executed before the main steps of the workchain.
 This allows for the definition of context variables, e.g.
+
 ```yaml
 ---
 setup:
 - "{{ 1 | to_ctx('count') }}"
 ```
+
 sets the `self.ctx.count` variable to `1`.
 
-### PostProcessing
+#### PostProcessing
+
 By defining a `postprocess` field, common operations can be performed that will run _after_ the execution of the `current` calcjob. For example
+
 ```yaml
 ---
 data:
@@ -66,10 +80,13 @@ steps:
     parameters.CONTROL.calculation: nscf
     parent_folder: "{{ ctx.scf_dir }}"
 ```
+
 Here we can observe a couple of new constructs. The first is `ctx.current`, signifying the currently executed calcjob (i.e. the `scf` calculation). Secondly, the `|` and `to_ctx` in `"{{ ctx.current.outputs['remote_folder'] | to_ctx('scf_dir') }}"` mean the value is piped through a the `to_ctx` filter, which assigns it to the variable `scf_dir`, stored in the workchain's context `self.ctx` for later referencing. Indeed we see that in the next step we retrieve this value using `"{{ ctx.scf_dir }}"` as the `parent_folder` input. Finally we note the line `parameters.CONTROL.calculation: nscf`, this simply means that we set a particular value in the `parameters` dictionary.
 
-### If
+#### If
+
 Steps can define an `if` field which contains a statement. If the statement is true, the step will be executed, otherwise it is ignored.
+
 ```yaml
 ---
 steps:
@@ -78,12 +95,15 @@ steps:
   inputs:
     <inputs>
 ```
-Here, depending on the previously set `ctx` variable, the step will run.
-#### note
-    the corresponding else statement would be `"{{ not ctx.should_run }}"`
 
-### While
+Here, depending on the previously set `ctx` variable, the step will run.
+
+> **Note** the corresponding else statement would be `"{{ not ctx.should_run }}"`
+
+#### While
+
 It is possible to specify a `while` field, with a sequence of steps that will be run until the while statement is false, e.g.:
+
 ```yaml
 ---
 steps:
@@ -95,12 +115,15 @@ steps:
       postprocess:
       - "{{ (ctx.count + 1) | to_ctx('count') }}"
 ```
-will run the same calcjob 4 times
-#### note
-    Don't forget to set the ctx.count variable to something in the setup step of the workchain or the postprocessing step of the previous calcjob.
 
-### Error
+will run the same calcjob 4 times
+
+> **Note** Don't forget to set the ctx.count variable to something in the setup step of the workchain or the postprocessing step of the previous calcjob.
+
+#### Error
+
 It is possible that one of the steps errors. The error code and message will always be reported by the workchain. It is also possible to explicitely specify an error to return from the workchain if this happens using:
+
 ```yaml
 ---
 steps:
@@ -111,23 +134,28 @@ steps:
     code: 23
     message: "The first pw calculation failed."
 ```
-### Further examples
+
+#### Further examples
+
 For a fully featured example, see the `bands.yaml` file in the examples directory which mimics largely the `PwBandsWorkchain` from the [aiida-quantumespresso](https://github.com/aiidateam/aiida-quantumespresso) package.
 
-# data/cuds.py
+## data/cuds.py
+
 An AiiDA plugin that interfaces CUDS with AiiDA DataNodes.
 For now, CUDS defined through [dlite](https://github.com/SINTEF/dlite) are supported
 
 **This is experimental, pre-alpha software**.
 
-
 ## Prerequisites
+
 As pre-alpha software, this package is **not** released on PyPI.
 Currently the only way to install the plugin is to clone the
 repository and use `pip`:
+
 ```bash
 pip install -e .
 ```
 
-# Acknowledgements
+## Acknowledgements
+
 The `DeclarativeChain` was developed and design with help and input of Simon Adorf (@csadorf).

--- a/execflow/workchains/declarative_chain.py
+++ b/execflow/workchains/declarative_chain.py
@@ -14,7 +14,7 @@ import jsonref
 from jsonschema import validate
 import plumpy
 import requests
-from ruamel.yaml import YAML
+import yaml
 
 # Copied from https://github.com/aiidalab/aiidalab/blob/90b334e6a473393ba22b915fdaf85d917fd947f4/aiidalab/registry/yaml.py
 # licensed under the MIT license
@@ -30,7 +30,7 @@ def my_fancy_loader(uri):
             response = REQUESTS.get(uri)
             response.raise_for_status()
             content = response.content
-        return YAML(typ="safe").load(content)
+        return yaml.safe_load(content)
     else:
         return jsonref.load_uri(uri)
 
@@ -245,7 +245,7 @@ class DeclarativeChain(WorkChain):
                 s = f.read()
                 s = s.replace("__DIR__", d)
                 if ext in (".yaml", ".yml"):
-                    tspec = YAML(typ="safe").load(s)
+                    tspec = yaml.safe_load(s)
                     spec = jsonref.JsonRef.replace_refs(tspec, loader=my_fancy_loader)
                 else:
                     spec = jsonref.load(s)
@@ -254,7 +254,7 @@ class DeclarativeChain(WorkChain):
             ext = splitext(self.inputs["workchain_specification"].filename)[1]
             with self.inputs["workchain_specification"].open(mode="r") as f:
                 if ext in (".yaml", ".yml"):
-                    tspec = YAML(typ="safe").load(f)
+                    tspec = yaml.safe_load(f.read())
                     spec = jsonref.JsonRef.replace_refs(tspec, loader=my_fancy_loader)
                 else:
                     spec = jsonref.load(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     'chevron>=0.14.0,<1',
     'DLite-Python>=0.5.1,<1',
     'jsonref==1.1.0',
-    # 'jsonschema~=4.22',  # dependency from aiida-core 2.4
+    'jsonschema>=3.2.0,<5',
     'oteapi-core>=0.6.1,<1',
     'oteapi-dlite>=0.2.0,<1',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ classifiers = [
 requires-python = '>=3.9,<3.12'
 
 dependencies = [
-    'aiida-core~=2.4',
+    'aiida-core~=2.1',
     'aiida-pseudo~=1.5',
-    'aiida-shell>=0.7.0,<1',
+    'aiida-shell>=0.6.0,<1',
     'cachecontrol>=0.14.0,<1',
     'chevron>=0.14.0,<1',
     'DLite-Python>=0.5.1,<1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,14 @@ dependencies = [
     'oteapi-dlite>=0.2.0,<1',
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pre-commit~=3.7",
+    "pytest~=8.2",
+    "pytest-cov~=5.0",
+    "pgtest~=1.3",
+]
+
 [project.urls]
 Home = 'https://github.com/H2020-OpenModel/ExecFlow'
 Source = 'https://github.com/H2020-OpenModel/ExecFlow'
@@ -133,13 +141,4 @@ plugins = ["pydantic.mypy"]
 [tool.setuptools.package-data]
 execflow = [
     "entities/*.json"
-]
-
-[project.optional-dependencies]
-dev = [
-    "pre-commit~=3.6",
-    "pylint~=3.0",
-    "pytest~=8.0",
-    "pytest-cov~=4.1",
-    "pgtest~=1.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,14 @@ classifiers = [
 requires-python = '>=3.9,<3.12'
 
 dependencies = [
-    'aiida-core~=2.5',
+    'aiida-core~=2.4',
     'aiida-pseudo~=1.5',
     'aiida-shell>=0.7.0,<1',
     'cachecontrol>=0.14.0,<1',
     'chevron>=0.14.0,<1',
     'DLite-Python>=0.5.1,<1',
     'jsonref==1.1.0',
-    'jsonschema~=4.22',
+    # 'jsonschema~=4.22',  # dependency from aiida-core 2.4
     'oteapi-core>=0.6.1,<1',
     'oteapi-dlite>=0.2.0,<1',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,11 @@ build-backend = 'flit_core.buildapi'
 [project]
 name = 'execflow'
 dynamic = ['version']
-authors = [{name = 'louisponet', email = 'louisponet@epfl.ch'}]
+authors = [
+    {name = 'louisponet', email = 'louisponet@epfl.ch'},
+    {name = 'Francesca L. Bleken', email = 'francesca.l.bleken@sintef.no'},
+    {name = 'Casper Welzel Andersen', email = 'casper.w.andersen@sintef.no'},
+]
 readme = 'README.md'
 license = {file = 'LICENSE'}
 description = "openmodel execflow"
@@ -17,21 +21,19 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.9,<3.12'
 
 dependencies = [
-    'aiida-core>=2.1.0,<3',
-    'oteapi-core>=0.6.1,<1',
-    'oteapi-dlite>=0.2.0,<1',
-    'DLite-Python>=0.5.1,<1',
-    'jsonschema~=4.21',
+    'aiida-core~=2.5',
+    'aiida-pseudo~=1.5',
+    'aiida-shell>=0.7.0,<1',
     'cachecontrol>=0.14.0,<1',
     'chevron>=0.14.0,<1',
-    'aiida-shell>=0.3.0',
-    'aiida-pseudo>=1.5.0,<2',
-    'jsonref>=1.1.0,<1.1.1',
-    'ruamel.yaml>=0.17.23,<0.17.33',
-
+    'DLite-Python>=0.5.1,<1',
+    'jsonref==1.1.0',
+    'jsonschema~=4.22',
+    'oteapi-core>=0.6.1,<1',
+    'oteapi-dlite>=0.2.0,<1',
 ]
 
 [project.urls]

--- a/tests/samples/pipe.yml
+++ b/tests/samples/pipe.yml
@@ -2,7 +2,7 @@ version: 1
 
 strategies:
   - dataresource: json_file
-    downloadUrl: "https://raw.githubusercontent.com/H2020-OpenModel/ExecFlow/cwa/close-21-migrate-to-pydantic-v2/tests/samples/sample2.json"
+    downloadUrl: "https://raw.githubusercontent.com/H2020-OpenModel/ExecFlow/main/tests/samples/sample2.json"
     mediaType: application/json
 
   - mapping: map_json_file


### PR DESCRIPTION
Based on the work done by @quaat, a Dockerfile has been added to run ExecFlow using a dedicated Python kernel in JupyterLab. The JupyterLab is based on the AiiDAlab Docker stack images, specifically the image [`base-with-services`](https://hub.docker.com/r/aiidalab/base-with-services/), which means everything necessary for running AiiDA is included in the running container.

Furthermore, the dependencies are updated and minimized to support running this Dockerfile environment.
Note, the latest supported version for AiiDAlab is AiiDA-Core v2.4.3, i.e., v2.5 (the current latest version) is still not supported.
When AiiDAlab is upgraded to use v2.5, the `jsonschema` dependency should be reinstated in this repository's `pyproject.toml` file, as that dependency has been removed from AiiDA-Core.

Furthermore, immediately before merging this PR, the installation branch for ExecFlow should be updated in the Dockerfile.